### PR TITLE
Update link for XDATA Tessera

### DIFF
--- a/XDATA-software.json
+++ b/XDATA-software.json
@@ -1366,9 +1366,9 @@
             "Jet Propulsion Laboratory"
         ],
         "Contributors":[
-            "Dr. Chris A. Mattmann", 
+            "Dr. Chris A. Mattmann",
             "Mr. Paul Ramirez",
-            "Mr. Maziyar Boustani", 
+            "Mr. Maziyar Boustani",
             "Ms. Shakeh Khudikyan",
             "Mr. Mike Joyce",
             "Mr. Rishi Verma",
@@ -3331,7 +3331,7 @@
         ],
         "Software":"Tessera",
         "Internal Link":"https://xd-wiki.xdata.data-tactics-corp.com:8443/pages/viewpage.action?pageId=7274499",
-        "External Link":"http://www.tesseradata.org/",
+        "External Link":"http://www.tessera.io/",
         "Public Code Repo":"https://github.com/tesseradata",
         "Instructional Material":"2014-07",
         "Stats":"Tessera",


### PR DESCRIPTION
The current link for the Tessera project in XDATA is out of date.  What's worse, the link currently exposed on the catalog has expired recently and it looks like someone else has purchased the domain and it now looks like a pretty nasty malware site.  Given that this is an obscure domain name for someone to be using for this purpose, it makes me wonder if the purpose of that site is targeted at the type of people who would be visiting the open catalog by exploiting the fact that the link became dead.  Anyway, this should be merged ASAP.

My editor removed a few end-of-line spaces as well.